### PR TITLE
fix(testnet): Switch to Decatur's infrastructure 

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -32,7 +32,11 @@ if (RESTAPI === "bitcoin.com") {
 if (RESTAPI === "rest.bitcoin.com") {
   config.BCHLIB = BCHJS.BitboxShim()
   config.MAINNET_REST = `https://rest.bitcoin.com/v2/`
-  config.TESTNET_REST = `https://trest.bitcoin.com/v2/`
+  //config.TESTNET_REST = `https://trest.bitcoin.com/v2/`
+
+  // Use Decatur's infrastructure until rest.bitcoin.com changes their Insight API.
+  config.TESTNET_REST = `http://decatur.hopto.org:13400/v3/`
+
   config.RESTAPI = "rest.bitcoin.com"
 }
 


### PR DESCRIPTION
The full node behind Bitcoin.com's testnet Insight API doesn't support the `BITBOX.Address.details()` call when used with the maximum of 20 addresses. I've opened up my own infrastructure to help the testnet-using dev community. This change is temporary until the infrastructure at rest.bitcoin.com can support this wallet.