### PR TITLE
Adding derivation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ line interface for this project is built with [oclif](https://oclif.io).
 Also, be sure to check out the design decisions and trade-offs that went into the
 creation of this project in the [docs directory](./docs)
 
-[![Build Status](https://travis-ci.org/christroutner/consolidating-coinjoin.svg?branch=master)](https://travis-ci.org/christroutner/consolidating-coinjoin)  [![Coverage Status](https://coveralls.io/repos/github/Bitcoin-com/bch-cli-wallet/badge.svg?branch=master)](https://coveralls.io/github/Bitcoin-com/bch-cli-wallet?branch=master) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Greenkeeper badge](https://badges.greenkeeper.io/christroutner/bch-cli-wallet.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/christroutner/bch-cli-wallet.svg?branch=master)](https://travis-ci.org/christroutner/bch-cli-wallet)  
+[![Coverage Status](https://coveralls.io/repos/github/christroutner/bch-cli-wallet/badge.svg?branch=master)](https://coveralls.io/github/christroutner/bch-cli-wallet?branch=master)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![Greenkeeper badge](https://badges.greenkeeper.io/christroutner/bch-cli-wallet.svg)](https://greenkeeper.io/)
 
 <!-- toc -->
 * [NPM Usage](#npm-usage)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`slp-cli-wallet create-wallet`](#slp-cli-wallet-create-wallet)
+* [`slp-cli-wallet derivation`](#slp-cli-wallet-derivation)
 * [`slp-cli-wallet get-address`](#slp-cli-wallet-get-address)
 * [`slp-cli-wallet get-key`](#slp-cli-wallet-get-key)
 * [`slp-cli-wallet hello`](#slp-cli-wallet-hello)
@@ -105,6 +106,32 @@ OPTIONS
 ```
 
 _See code: [src/commands/create-wallet.js](https://github.com/christroutner/bch-cli-wallet/blob/v1.5.0/src/commands/create-wallet.js)_
+
+## `slp-cli-wallet derivation`
+
+Display or set the derivation path used by the wallet.
+
+```
+USAGE
+  $ slp-cli-wallet derivation
+
+OPTIONS
+  -n, --name=name  name to print
+  -s, --save=save  save a new derivation path
+
+DESCRIPTION
+  This command is used to display the derivation path used by the wallet. The -s
+  flag can be used to save a new derivation path.
+
+  Common derivation paths used:
+  145 - BIP44 standard path for Bitcoin Cash
+  245 - BIP44 standard path for SLP tokens
+  0 - Used by common software like the Bitcoin.com wallet and Honest.cash
+
+  Wallets use the 245 derivation path by default.
+```
+
+_See code: [src/commands/derivation.js](https://github.com/christroutner/bch-cli-wallet/blob/v1.5.0/src/commands/derivation.js)_
 
 ## `slp-cli-wallet get-address`
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ line interface for this project is built with [oclif](https://oclif.io).
 Also, be sure to check out the design decisions and trade-offs that went into the
 creation of this project in the [docs directory](./docs)
 
-[![Build Status](https://travis-ci.org/christroutner/bch-cli-wallet.svg?branch=master)](https://travis-ci.org/christroutner/bch-cli-wallet)  
-[![Coverage Status](https://coveralls.io/repos/github/christroutner/bch-cli-wallet/badge.svg?branch=master)](https://coveralls.io/github/christroutner/bch-cli-wallet?branch=master)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![Greenkeeper badge](https://badges.greenkeeper.io/christroutner/bch-cli-wallet.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/christroutner/bch-cli-wallet.svg?branch=master)](https://travis-ci.org/christroutner/bch-cli-wallet) [![Coverage Status](https://coveralls.io/repos/github/christroutner/bch-cli-wallet/badge.svg?branch=master)](https://coveralls.io/github/christroutner/bch-cli-wallet?branch=master) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Greenkeeper badge](https://badges.greenkeeper.io/christroutner/bch-cli-wallet.svg)](https://greenkeeper.io/)
 
 <!-- toc -->
 * [NPM Usage](#npm-usage)

--- a/src/commands/derivation.js
+++ b/src/commands/derivation.js
@@ -1,0 +1,88 @@
+/*
+  Changes the derivation path used by the wallet to generate addresses. Common
+  derivation settings:
+  145 - BIP44 standard path for Bitcoin Cash
+  245 - BIP44 standard path for SLP tokens
+  0 - Used by common software like the Bitcoin.com wallet and Honest.cash
+*/
+
+"use strict"
+
+const AppUtils = require("../util")
+const appUtils = new AppUtils()
+
+const { Command, flags } = require("@oclif/command")
+
+class Derivation extends Command {
+  async run() {
+    try {
+      const { flags } = this.parse(Derivation)
+
+      // Ensure flags meet qualifiying critieria.
+      this.validateFlags(flags)
+
+      const filename = `${__dirname}/../../wallets/${flags.name}.json`
+      const walletData = appUtils.openWallet(filename)
+      console.log(`Current derivation path: ${walletData.derivation}`)
+
+      // Save a new derivation.
+      if (flags.save) this.saveDerivation(flags, filename, walletData)
+    } catch (err) {
+      //if (err.message) console.log(err.message)
+      //else console.log(`Error in .run: `, err)
+      console.log(`Error in derivation.js/run: `, err)
+    }
+  }
+
+  saveDerivation(flags, filename, walletData) {
+    try {
+      // Set the new derivation path.
+      walletData.derivation = flags.save
+
+      // Save the wallet.
+      appUtils.saveWallet(filename, walletData)
+
+      console.log(`New derivation path of ${flags.save} saved to wallet file.`)
+    } catch (err) {
+      console.log(`Error in derivation.js/saveDerivation()`)
+      throw err
+    }
+  }
+
+  // Validate the proper flags are passed in.
+  validateFlags(flags) {
+    // Exit if wallet not specified.
+    const name = flags.name
+    if (!name || name === "")
+      throw new Error(`You must specify a wallet with the -n flag.`)
+
+    const save = flags.save
+    if (save && save === "")
+      throw new Error(`You must specify a new derivation path to save.`)
+
+    const intCheck = parseInt(save)
+    if (save && isNaN(intCheck))
+      throw new Error(`Derivation path must be an integer.`)
+
+    return true
+  }
+}
+
+Derivation.description = `Display or set the derivation path used by the wallet.
+This command is used to display the derivation path used by the wallet. The -s
+flag can be used to save a new derivation path.
+
+Common derivation paths used:
+145 - BIP44 standard path for Bitcoin Cash
+245 - BIP44 standard path for SLP tokens
+0 - Used by common software like the Bitcoin.com wallet and Honest.cash
+
+Wallets use the 245 derivation path by default.
+`
+
+Derivation.flags = {
+  name: flags.string({ char: "n", description: "name to print" }),
+  save: flags.string({ char: "s", description: "save a new derivation path" })
+}
+
+module.exports = Derivation

--- a/src/commands/derivation.js
+++ b/src/commands/derivation.js
@@ -26,7 +26,15 @@ class Derivation extends Command {
       console.log(`Current derivation path: ${walletData.derivation}`)
 
       // Save a new derivation.
-      if (flags.save) this.saveDerivation(flags, filename, walletData)
+      if (flags.save) {
+        const result = this.saveDerivation(flags, filename, walletData)
+
+        if (result) {
+          console.log(
+            `New derivation path of ${flags.save} saved to wallet file.`
+          )
+        }
+      }
     } catch (err) {
       //if (err.message) console.log(err.message)
       //else console.log(`Error in .run: `, err)
@@ -34,6 +42,7 @@ class Derivation extends Command {
     }
   }
 
+  // Update the wallet file with the new derivation path.
   saveDerivation(flags, filename, walletData) {
     try {
       // Set the new derivation path.
@@ -42,7 +51,7 @@ class Derivation extends Command {
       // Save the wallet.
       appUtils.saveWallet(filename, walletData)
 
-      console.log(`New derivation path of ${flags.save} saved to wallet file.`)
+      return true
     } catch (err) {
       console.log(`Error in derivation.js/saveDerivation()`)
       throw err

--- a/test/commands/a12.derivation.test.js
+++ b/test/commands/a12.derivation.test.js
@@ -1,0 +1,224 @@
+/*
+  TODO:
+
+
+*/
+
+"use strict"
+
+const assert = require("chai").assert
+const sinon = require("sinon")
+
+// Library under test.
+const Derivation = require("../../src/commands/derivation")
+const config = require("../../config")
+
+// Mock data
+const testwallet = require("../mocks/testwallet.json")
+const { bitboxMock } = require("../mocks/bitbox")
+const utilMocks = require("../mocks/util")
+
+// Inspect utility used for debugging.
+const util = require("util")
+util.inspect.defaultOptions = {
+  showHidden: true,
+  colors: true,
+  depth: 1
+}
+
+// Set default environment variables for unit tests.
+if (!process.env.TEST) process.env.TEST = "unit"
+
+describe("#derivation", () => {
+  let BITBOX
+  let mockedWallet
+  let derivation
+  let sandbox
+
+  beforeEach(() => {
+    // By default, use the mocking library instead of live calls.
+    BITBOX = bitboxMock
+    mockedWallet = Object.assign({}, testwallet) // Clone the testwallet
+
+    sandbox = sinon.createSandbox()
+
+    derivation = new Derivation()
+    derivation.BITBOX = BITBOX
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe("#validateFlags", () => {
+    it("should throw error if name is not supplied.", () => {
+      try {
+        derivation.validateFlags({})
+      } catch (err) {
+        assert.include(
+          err.message,
+          `You must specify a wallet with the -n flag`,
+          "Expected error message."
+        )
+      }
+    })
+
+    it("should throw error is save flag is specified without argument", () => {
+      try {
+        const flags = {
+          name: `testwallet`,
+          save: undefined
+        }
+
+        derivation.validateFlags(flags)
+      } catch (err) {
+        assert.include(
+          err.message,
+          `Flag --save expects a value`,
+          "Expected error message."
+        )
+      }
+    })
+
+    it("should throw error if save argument is not an integer", () => {
+      try {
+        const flags = {
+          name: `testwallet`,
+          save: `abc`
+        }
+
+        derivation.validateFlags(flags)
+      } catch (err) {
+        assert.include(
+          err.message,
+          `Derivation path must be an integer`,
+          "Expected error message."
+        )
+      }
+    })
+  })
+
+  describe("#saveDerivation", () => {
+    it("should save the new derivation path to the wallet file", () => {
+      const filename = `${__dirname}/../../wallets/test123.json`
+
+      const flags = {
+        name: `test123`,
+        save: `145`
+      }
+
+      const result = derivation.saveDerivation(flags, filename, mockedWallet)
+
+      assert.equal(result, true, "Successful save expected")
+    })
+  })
+
+  // describe("#getTokenUtxos", () => {
+  //   it("should throw an error if there are no matching token utxos in wallet.", () => {
+  //     try {
+  //       const tokenId = `c4b0d62156b3fa5c8f3436079b5394f7edc1bef5dc1cd2f9d0c4d46f82cca479`
+  //       sendTokens.getTokenUtxos(tokenId, mockedWallet)
+  //     } catch (err) {
+  //       assert.include(
+  //         err.message,
+  //         `No tokens in the wallet matched the given token ID`,
+  //         "Expected error message."
+  //       )
+  //     }
+  //   })
+  //
+  //   it("should return UTXOs matching token ID.", () => {
+  //     const tokenId =
+  //       "73db55368981e4878440637e448d4abe7f661be5c3efdcbcb63bd86a01a76b5a"
+  //
+  //     const tokenUtxos = sendTokens.getTokenUtxos(tokenId, mockedWallet)
+  //     //console.log(`tokenUtxos: ${JSON.stringify(tokenUtxos, null, 2)}`)
+  //
+  //     assert.equal(tokenUtxos.length, 2) // Should return 2 UTXOs from mock wallet.
+  //   })
+  // })
+  //
+  // // These are unit tests only.
+  // if (process.env.TEST === "unit") {
+  //   describe("#getBchUtxos", () => {
+  //     it("should throw error if there are no BCH Utxos to pay for SLP transaction.", async () => {
+  //       sandbox.stub(sendTokens.appUtils, "getUTXOs").resolves([])
+  //
+  //       try {
+  //         await sendTokens.getBchUtxos(mockedWallet)
+  //
+  //         assert.equal(true, false, "Unexpected result!")
+  //       } catch (err) {
+  //         assert.include(
+  //           err.message,
+  //           `No BCH UTXOs found in wallet. No way to pay miner fees for transaction`,
+  //           "Expected error message."
+  //         )
+  //       }
+  //     })
+  //
+  //     it("should return non-SLP Utxos", async () => {
+  //       sandbox.stub(sendTokens.appUtils, "getUTXOs").resolves([
+  //         {
+  //           txid:
+  //             "fc2d806e1395e6fbc57f1dbedbd6e04794e2105d1c8915c49539b5041b12345c",
+  //           vout: 1,
+  //           amount: 0.1,
+  //           satoshis: 10000000,
+  //           height: 1296652,
+  //           confirmations: 1,
+  //           hdIndex: 11
+  //         },
+  //         {
+  //           txid:
+  //             "fc2d806e1395e6fbc57f1dbedbd6e04794e2105d1c8915c49539b5041b12345c",
+  //           vout: 1,
+  //           amount: 0.1,
+  //           satoshis: 10000000,
+  //           height: 1296652,
+  //           confirmations: 1,
+  //           hdIndex: 11
+  //         }
+  //       ])
+  //
+  //       const utxos = await sendTokens.getBchUtxos(mockedWallet)
+  //
+  //       assert.isArray(utxos)
+  //     })
+  //   })
+  // }
+  //
+  // describe("#sendTokens", () => {
+  //   it("should send SLP on testnet", async () => {
+  //     const qty = 1.5 // tokens to send in an integration test.
+  //     const utxo = {
+  //       txid:
+  //         "26564508facb32a5f6893cb7bdfd2dcc264b248a1aa7dd0a572117667418ae5b",
+  //       vout: 0,
+  //       scriptPubKey: "76a9148687a941392d82bf0af208779c3b147e2fbadafa88ac",
+  //       amount: 0.03,
+  //       satoshis: 3000000,
+  //       height: 1265272,
+  //       confirmations: 733,
+  //       legacyAddress: "mjSPWfCwCgHZC27nS8GQ4AXz9ehhb2GFqz",
+  //       cashAddress: "bchtest:qq4sx72yfuhqryzm9h23zez27n6n24hdavvfqn2ma3",
+  //       hdIndex: 0
+  //     }
+  //     const sendToAddr = `bchtest:qzsfqeqtdk6plsvglccadkqtf0trf2nyz58090e6tt`
+  //
+  //     const hex = await sendTokens.sendTokens(
+  //       utxo,
+  //       qty,
+  //       utxo.cashAddress,
+  //       sendToAddr,
+  //       mockedWallet,
+  //       mockedWallet.SLPUtxos
+  //     )
+  //
+  //     //console.log(`hex: ${hex}`)
+  //
+  //     assert.isString(hex)
+  //   })
+
+  // })
+})

--- a/test/mocks/testwallet.json
+++ b/test/mocks/testwallet.json
@@ -4,6 +4,7 @@
   "rootAddress": "bchtest:qqfzejzg9647tadnlemes6kjjmd948ne25jx6el90r",
   "balance": 0.09999751999999999,
   "nextAddress": 4,
+  "derivation": 245,
   "hasBalance": [
     {
       "index": 2,


### PR DESCRIPTION
The new `derivation` command allows users to easily switch the derivation path of their wallet. This makes importing wallets from different apps much easier. Also allows the new SLP features to be backwards compatible with previous versions of bch-cli-wallet.